### PR TITLE
Increase orderAssembly placeholder text size

### DIFF
--- a/src/pages/MainAdmin/OrderAssembly.jsx
+++ b/src/pages/MainAdmin/OrderAssembly.jsx
@@ -10,7 +10,11 @@ const OrderAssembly = () => (
       <div id="heading">
         <h2>Order Assembly</h2>
       </div>
-      <div style={{ padding: "20px", textAlign: "center" }}>Coming Soon...</div>
+      <div
+        style={{ padding: "20px", textAlign: "center", fontSize: "4em" }}
+      >
+        Coming Soon...
+      </div>
     </div>
   </>
 );


### PR DESCRIPTION
## Summary
- adjust placeholder text size on Order Assembly page

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618794fa548322bdcc6b418c7261eb